### PR TITLE
Add step-cli to acme clients

### DIFF
--- a/src/_data/clients.json
+++ b/src/_data/clients.json
@@ -305,6 +305,30 @@
         "https://img.shields.io/github/stars/cert-manager/cert-manager",
         "https://img.shields.io/github/last-commit/cert-manager/cert-manager"
       ]
+    },
+    {
+      "title": "step cli",
+      "summary": "A standalone, general-purpose PKI toolkit",
+      "website": "https://smallstep.com/cli/",
+      "source": "https://github.com/smallstep/cli",
+      "docs": "https://smallstep.com/docs/step-ca/acme-basics",
+      "community": "https://u.step.sm/discord",
+      "categories": [
+        "cli",
+        "integration"
+      ],
+      "tech": [
+        "go"
+      ],
+      "os": [
+        "windows",
+        "linux",
+        "macOS"
+      ],
+      "badges": [
+        "https://img.shields.io/github/stars/smallstep/cli",
+        "https://img.shields.io/github/last-commit/smallstep/cli"
+      ]
     }
   ]
 }


### PR DESCRIPTION
[Step](https://smallstep.com/cli/) which is a general-purpose PKI toolkit, includes a built-in ACME client. It has an active user base and community.